### PR TITLE
RDKEMW-479: Boot up time for RDKE RDKV

### DIFF
--- a/power/deepSleep.c
+++ b/power/deepSleep.c
@@ -196,18 +196,14 @@ static void SetPwrMgrDeepSleepMode(void *data)
                     status = PLAT_DS_SetDeepSleep(deep_sleep_wakeup_timer,&userWakeup, nwStandbyMode_gs);
                     LOG("Device resumed from Deep sleep Mode.status :%d  \r\n",status);
 
-                    #ifdef PLATCO_BOOTTO_STANDBY
                     pwr_param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP;
                     LOG("Set newState to IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP \n");
-                    #else
-                    pwr_param.newState = IARM_BUS_PWRMGR_POWERSTATE_ON;
-                    LOG("Set newState to IARM_BUS_PWRMGR_POWERSTATE_ON \n");
-                    #endif
 
                     if(status != 0) {
                         sleep(5);
                         retryCount++;
                         if(retryCount >= 5) {
+                            IsDeviceInDeepSleep = DeepSleepStatus_Failed;
                             LOG(" ERROR: Device failed to enter into Deep sleep Mode.  Set Power state newState= %d\n", pwr_param.newState);
                             LOG("calling _SetPowerState() with  newState= %d\n", pwr_param.newState);
                             retCode = _SetPowerState((void *)&pwr_param);


### PR DESCRIPTION
Reason for change:
	Boot up time for RDKE RDKV. deepsleep to standby fix
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>