### PR TITLE
RDKEMW-650 : Remove product names iarmmgrs  and teenable

### DIFF
--- a/power/therm_mgr.c
+++ b/power/therm_mgr.c
@@ -70,7 +70,7 @@ extern "C"
 #define RFC_DATA_ThermalProtection_DECLOCK_GRACE_INTERVAL
 #define RFC_DATA_ThermalProtection_DECLOCK_SAFE_THRESHOLD
 
-#ifndef REALTEK_SPECIFIC
+#ifndef MFR_TEMP_CLOCK_READ
 /* Temperature (in celcus) at which box will ALWAYS be rebooted */
 static int thermal_reboot_critical_threshold        = 120;
 /* Temperature (in celcus) at which box will be rebooted after grace_interval has passed
@@ -113,7 +113,7 @@ static int thermal_declock_grace_interval           = 60;
 // the interval at which temperature will be polled from lower layers
 static int thermal_poll_interval        = 30; //in seconds
 // the interval after which reboot will happen if the temperature goes above reboot threshold
-#else //REALTEK_SPECIFIC
+#else //MFR_TEMP_CLOCK_READ
 #define REBOOT_CRITICAL    110
 #define REBOOT_CONCERN     102
 #define REBOOT_SAFE        100
@@ -173,7 +173,7 @@ static int thermal_declock_grace_interval           = DECLOCK_GRACE_INTERVAL;
 static int thermal_poll_interval        = POLL_INTERVAL; //in seconds
 // the interval after which reboot will happen if the temperature goes above reboot threshold
  
-#endif //REALTEK_SPECIFIC
+#endif //MFR_TEMP_CLOCK_READ
 
 
 //Did we already read config params once ?

--- a/power/therm_mon.c
+++ b/power/therm_mon.c
@@ -54,7 +54,7 @@ int uint32_compare( const void* a, const void* b)
     else return 1;
 }
 
-#ifdef REALTEK_SPECIFIC
+#ifdef MFR_TEMP_CLOCK_READ
 int PLAT_API_DetemineClockSpeeds(uint32_t *cpu_rate_Normal, uint32_t *cpu_rate_Scaled, uint32_t *cpu_rate_Minimal)
 {
 	int retValue = 0;
@@ -239,7 +239,7 @@ int PLAT_API_GetTempThresholds(float *tempHigh, float *tempCritical)
 	return result;
 }
 
-#else //REALTEK_SPECIFIC
+#else //MFR_TEMP_CLOCK_READ
 int PLAT_API_DetemineClockSpeeds(uint32_t *cpu_rate_Normal, uint32_t *cpu_rate_Scaled, uint32_t *cpu_rate_Minimal)
 {
     FILE * fp;
@@ -414,7 +414,7 @@ int PLAT_API_GetTempThresholds(float *tempHigh, float *tempCritical)
 
     return result;
 }
-#endif //REALTEK_SPECIFIC
+#endif //MFR_TEMP_CLOCK_READ
 #endif //ENABLE_THERMAL_PROTECTION
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reason for change:
	Remove product names iarmmgrs  and teenable
     mfr temp clock read
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>