### PR TITLE
RDKEMW-3368: Remove call to set background colour to blue on HDCP Fai…

### DIFF
--- a/dsmgr/dsMgr.c
+++ b/dsmgr/dsMgr.c
@@ -403,8 +403,8 @@ static void _EventHandler(const char *owner, IARM_EventId_t eventId, void *data,
 					{
 						INT_ERROR("Changed status to HDCP Authentication Fail   !!!!!!!! ..\r\n");
 						HDCPeventData.data.systemStates.state =  0;
-                                                setBGColor(dsVIDEO_BGCOLOR_BLUE);
-                                                bHDCPAuthenticated = false;
+						
+						bHDCPAuthenticated = false;
 						if (!IsIgnoreEdid_gs) {
                                                     _SetVideoPortResolution();
 						}


### PR DESCRIPTION
…lure (#58)

Reason for change: Setting background colour to blue is a legacy requirement and is no longer required.
Test Procedure: Build and verify.
Risks: Low
Priority: P1
Signed-off-by: Matthew Crowson <matthew.crowson@sky.uk>

Change-Id: Ia97ff39eecb32bb2c4771e208be7affcb3ab3ad7