### PR TITLE
RDK-57460: Enabling segmented global profile in RDKE

### DIFF
--- a/conf/dsmgr.service
+++ b/conf/dsmgr.service
@@ -24,7 +24,7 @@ OnFailure=reboot-notifier@%i.service
 [Service]
 Type=notify
 ExecStartPre=/bin/mkdir -p /opt/persistent/ds
-ExecStart=/usr/bin/dsMgrMain
+ExecStart=/bin/sh -c '/usr/bin/dsMgrMain'
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/mfrmgr.service
+++ b/conf/mfrmgr.service
@@ -22,7 +22,7 @@ After=iarmbusd.service mfrlibapp.service
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/mfrMgrMain
+ExecStart=/bin/sh -c '/usr/bin/mfrMgrMain'
 Restart=always
 
 [Install]

--- a/conf/sysmgr.service
+++ b/conf/sysmgr.service
@@ -21,7 +21,7 @@ Description=IARM Mgr Daemon SYS MGR
 After=lighttpd.service iarmbusd.service
 
 [Service]
-ExecStart=/usr/bin/sysMgrMain
+ExecStart=/bin/sh -c '/usr/bin/sysMgrMain'
 Type=notify
 Restart=always
 


### PR DESCRIPTION
Reason for change: Apparmor profiles should run in expected mode
Test Procedure: As mentioned in the ticket
Risks: Medium
Priority: P1