### PR TITLE
RDKEMW-4192: Integrate OSS 4.6.0

### DIFF
--- a/mfr/Makefile
+++ b/mfr/Makefile
@@ -67,7 +67,7 @@ library: mfrMgr.o
 
 executable: mfrMgrMain.o mfrMgr.o
 	@echo "Building $(EXECUTABLE) ...."
-	$(CC) $(CFLAGS) $(LDFLAGS) $(MFR_LDFLAGS) mfrMgr.o mfrMgrMain.o -o $(EXECUTABLE)
+	$(CC) $(CFLAGS) $(LDFLAGS) mfrMgr.o mfrMgrMain.o -o $(EXECUTABLE)
 
 %.o: %.c
 	@echo "Building $@ ...."


### PR DESCRIPTION
Reason for change: [DO NO MERGE] removed MFR_CDFLAG hence removing xsign reference in TV platform.
Test Procedure: Build and verify, should not be any run-time issues.