### PR TITLE
RDKEMW-6339: Fixes for Audio port not enabled

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -47,7 +47,7 @@ cd rfc
 autoreconf -i
 ./configure --enable-rfctool=yes --enable-tr181set=yes
 cd rfcapi
-make librfcapi_la_CPPFLAGS="-I/usr/include/cjson"
+make librfcapi_la_CPPFLAGS="-I/usr/include/cjson" CXXFLAGS="$CXXFLAGS -DUSE_IARMBUS"
 make install
 export RFC_PATH=$ROOT/rfc
 

--- a/stubs/ds_stubs.cpp
+++ b/stubs/ds_stubs.cpp
@@ -63,6 +63,16 @@ namespace device{
 	void VideoOutputPort::disable() {
 	}
 
+	void AudioOutputPort::enable() {
+	}
+
+	void AudioOutputPort::disable() {
+	}
+
+	bool AudioOutputPort::getEnablePersist () const {
+		return true;
+	}
+
 	void Manager::load() {
 	}
 


### PR DESCRIPTION
RDKEMW-6339: Fixes for Audio port not enabled
* RDKEMW-6339: No Audio heard on optical speaker after wakeup

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>