### PR TITLE
RDKEMW-11264 : logrotate.service failure is observed

### DIFF
--- a/dsmgr/dsMgr.c
+++ b/dsmgr/dsMgr.c
@@ -88,7 +88,6 @@ static dsDisplayEvent_t edisplayEventStatus = dsDISPLAY_EVENT_MAX;
 static pthread_t edsHDMIHPDThreadID; // HDMI HPD - HDMI Hot Plug detect events
 static pthread_mutex_t tdsMutexLock;
 static pthread_cond_t  tdsMutexCond;
-static volatile bool dsMgr_thread_exit_flag = false;
 static void* _DSMgrResnThreadFunc(void *arg);
 static void _setAudioMode();
 void _setEASAudioMode();
@@ -355,7 +354,6 @@ static gboolean heartbeatMsg(gpointer data)
 IARM_Result_t DSMgr_Stop()
 {
     IARM_Result_t iarmStatus = IARM_RESULT_SUCCESS;
-    dsMgr_thread_exit_flag = true;
     if(dsMgr_Gloop)
     {
         g_main_loop_quit(dsMgr_Gloop);

--- a/dsmgr/dsMgr.c
+++ b/dsmgr/dsMgr.c
@@ -1006,15 +1006,13 @@ static void* _DSMgrResnThreadFunc(void *arg)
 {
 	dsDisplayEvent_t edisplayEventStatusLocal = dsDISPLAY_EVENT_MAX;
 	/* Loop */
-	while (!dsMgr_thread_exit_flag)
+	while (1)
 	{
 		INT_INFO ("_DSMgrResnThreadFunc... wait for for HDMI or Tune Ready Events \r\n");
 
 		/*Wait for the Event*/
 		pthread_mutex_lock(&tdsMutexLock);
-		while (!dsMgr_thread_exit_flag && edisplayEventStatus == dsDISPLAY_EVENT_MAX) {
-			pthread_cond_wait(&tdsMutexCond, &tdsMutexLock);
-		}
+		pthread_cond_wait(&tdsMutexCond, &tdsMutexLock);
 		edisplayEventStatusLocal = edisplayEventStatus;
 		pthread_mutex_unlock(&tdsMutexLock);
 		INT_INFO("%s: Setting Resolution On:: HDMI %s Event  with TuneReady status = %d \r\n",


### PR DESCRIPTION
RDKEMW-11264 : logrotate.service failure is observed

Reason for change:
Fixing log spam
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>