### PR TITLE
RDKEMW-16000: Add refreshHandles in libds.

### DIFF
--- a/conf/dsmgr.service
+++ b/conf/dsmgr.service
@@ -24,6 +24,7 @@ After=lighttpd.service iarmbusd.service sysmgr.service wpeframework-powermanager
 Type=notify
 ExecStartPre=/bin/mkdir -p /opt/persistent/ds
 ExecStart=/bin/sh -c '/usr/bin/dsMgrMain'
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/dsmgr/dsMgr.c
+++ b/dsmgr/dsMgr.c
@@ -335,6 +335,28 @@ IARM_Result_t DSMgr_Start()
     INT_INFO("Set resolution during dsMgr init .. \r\n");
     _SetVideoPortResolution(); 
     setupPlatformConfig();
+
+    /* Notify all libds clients (e.g. DisplaySettings plugin) that dsmgr has
+     * fully restarted and all HAL handles are now valid.
+     *
+     * Clients that registered for IARM_BUS_DSMGR_EVENT_RESTARTED will call
+     * refreshAllHandles() on their local config singletons to replace any
+     * stale intptr_t handles left over from the previous dsmgr process.
+     *
+     * Broadcast AFTER dsMgr_init(), _SetVideoPortResolution(), and power
+     * controller init so the client can immediately call any dsXxx RPC and
+     * get a valid response.
+     */
+    iarmStatus = IARM_Bus_BroadcastEvent(IARM_BUS_DSMGR_NAME,
+                                          (IARM_EventId_t)IARM_BUS_DSMGR_EVENT_RESTARTED,
+                                          NULL, 0);
+    if (IARM_RESULT_SUCCESS != iarmStatus) {
+        INT_ERROR("[DSMgr] Failed to broadcast IARM_BUS_DSMGR_EVENT_RESTARTED (ret=%d)\r\n",
+                  iarmStatus);
+    } else {
+        INT_INFO("[DSMgr] IARM_BUS_DSMGR_EVENT_RESTARTED broadcast OK\r\n");
+    }
+
     return IARM_RESULT_SUCCESS;
 }
 

--- a/dsmgr/dsMgr.c
+++ b/dsmgr/dsMgr.c
@@ -346,10 +346,17 @@ IARM_Result_t DSMgr_Start()
      * Broadcast AFTER dsMgr_init(), _SetVideoPortResolution(), and power
      * controller init so the client can immediately call any dsXxx RPC and
      * get a valid response.
+     *
+     * NOTE: IARM_Bus_BroadcastEvent requires a non-NULL data pointer — pass
+     * a zeroed EventData struct even though this event carries no payload.
      */
-    iarmStatus = IARM_Bus_BroadcastEvent(IARM_BUS_DSMGR_NAME,
-                                          (IARM_EventId_t)IARM_BUS_DSMGR_EVENT_RESTARTED,
-                                          NULL, 0);
+    {
+        IARM_Bus_DSMgr_EventData_t eventData;
+        memset(&eventData, 0, sizeof(eventData));
+        iarmStatus = IARM_Bus_BroadcastEvent(IARM_BUS_DSMGR_NAME,
+                                              (IARM_EventId_t)IARM_BUS_DSMGR_EVENT_RESTARTED,
+                                              (void *)&eventData, sizeof(eventData));
+    }
     if (IARM_RESULT_SUCCESS != iarmStatus) {
         INT_ERROR("[DSMgr] Failed to broadcast IARM_BUS_DSMGR_EVENT_RESTARTED (ret=%d)\r\n",
                   iarmStatus);


### PR DESCRIPTION
Reason for change: Broadcast IARM_BUS_DSMGR_EVENT_RESTARTED from dsmgr.
Test Procedure: refer RDKEMW-16000
Risks: High
Signed-off-by:gsanto722 <grandhi_santoshkumar@comcast.com>