### PR TITLE
RDKEMW-19900: Update rebootinfo when dsmgr,iarmbusd crash. 

### DIFF
--- a/conf/dsmgr.service
+++ b/conf/dsmgr.service
@@ -24,7 +24,17 @@ After=lighttpd.service iarmbusd.service sysmgr.service wpeframework-powermanager
 [Service]
 Type=notify
 ExecStartPre=/bin/mkdir -p /opt/persistent/ds
+ExecStartPre=/usr/bin/systemd-run --unit=dsmgr-monitor /bin/sh /usr/lib/iarm-monitor.sh dsmgr dsMgrMain
 ExecStart=/bin/sh -c '/usr/bin/dsMgrMain'
+# Runs only after READY=1 is confirmed (Type=notify guarantee).
+ExecStartPost=/bin/touch /tmp/dsmgr.ready
+# dsMgrMain sent READY=1 — stop the start-phase watchdog (non-blocking).
+ExecStartPost=-/bin/systemctl stop --no-block dsmgr-monitor
+# /opt/.dsmgr_restart_count is removed after dsmgr starts.
+ExecStartPost=/bin/rm -f /opt/.dsmgr_restart_count
+# Stop the watchdog if still running (non-blocking — avoids delaying dsmgr shutdown).
+ExecStop=-/bin/systemctl stop --no-block dsmgr-monitor
+ExecStopPost=/bin/sh /usr/lib/iarm-reboot.sh dsmgr dsMgrMain
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* RDKEMW-19900: Update rebootinfo when dsmgr crash.

Reason for change: Update rebootinfo when dsmgr,iarmbusd crash. 
Test Procedure: refer RDKEMW-19900
Risks: High
Signed-off-by:gsanto722 <grandhi_santoshkumar@comcast.com>